### PR TITLE
[BOT-42] Scheduled rcm now sends image file

### DIFF
--- a/src/jobs/index.js
+++ b/src/jobs/index.js
@@ -42,7 +42,7 @@ class Jobs {
       const map = Fires.getMap();
 
       try {
-        this.client.channels.get(channels.FIRES_CHANNEL_ID).send(map);
+        this.client.channels.get(channels.FIRES_CHANNEL_ID).send('Risco de Incêndio para hoje', { files: [map] });
       } catch (e) {
         //
       }


### PR DESCRIPTION
## Description
This pull request addresses issue [BOT-42](https://github.com/vostpt/bot/issues/42).

## Task items:
- [x] Instead of sending just image url, now Discord won't cache rcm image from previous days.