### PR TITLE
[FIX] ESLint: disable linebreak-style

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,9 +14,8 @@ module.exports = {
   },
   parserOptions: {
     ecmaVersion: 2018
-  }
-  // "plugins": ["prettier"],
-  // "rules": {
-  //   "prettier/prettier": "error",
-  // },
+  },
+  rules: {
+    "linebreak-style": "off"
+  },
 };


### PR DESCRIPTION
## Description
This aims to allow developers using multiple platforms (windows, unix, etc) to be able to use different linebreaks.

It turns off the eslint rule.

## Task items:
- [X] Turn ESLint rule off;