### PR TITLE
[BOT-58]: !acronimo command not fetching acronyms

### DIFF
--- a/src/api/Acronyms.js
+++ b/src/api/Acronyms.js
@@ -1,10 +1,12 @@
-const api = require('axios');
+const axios = require('axios');
 
-const get = (acronym) => {
-  const baseURl = 'https://vost.mariosantos.net/api';
+const api = axios.create({
+  headers: {
+    'Content-Type': 'application/vnd.api+json',
+  },
+});
 
-  return api.get(`${baseURl}/acronym/${acronym.toLowercase()}.php`);
-};
+const get = acronym => api.get(`https://api.vost.pt/v1/acronyms/?search=${acronym.toLowerCase()}&exact=1`);
 
 module.exports = {
   get,

--- a/src/commands/acronym.js
+++ b/src/commands/acronym.js
@@ -1,4 +1,4 @@
-const { AcronymsApi } = require('../api');
+const { Acronyms } = require('../services');
 
 module.exports = {
   name: 'acronimo',
@@ -17,22 +17,25 @@ module.exports = {
   */
   async execute(message, args) {
     if (this.args && args.length === 0) {
-      try {
-        message.reply(`*Give me more data* para eu poder trabalhar!\n${this.usage}`);
-      } catch (e) {
-        //
-      }
+      message.reply(`*Give me more data* para eu poder trabalhar!\n${this.usage}`);
 
       return;
     }
 
-    const [acronym] = args;
-    try {
-      const { data = {} } = await AcronymsApi.get(acronym);
+    const [requestedAcronym] = args;
+    const { data: acronyms = [] } = await Acronyms.getExactAcronym(requestedAcronym);
+    const [acronym] = acronyms;
 
-      message.channel.send(`${data.acronym} - ${data.description}`);
-    } catch (e) {
-      message.reply('Esse acrónimo não consta na base de dados!');
+    if (!acronym) {
+      message.channel.send('Não reconheço esse acrónimo');
+      return;
     }
+
+    const {
+      initials,
+      meaning,
+    } = acronym.attributes;
+
+    message.channel.send(`${initials} - ${meaning}`);
   },
 };

--- a/src/commands/acronym.js
+++ b/src/commands/acronym.js
@@ -17,7 +17,7 @@ module.exports = {
   */
   async execute(message, args) {
     if (this.args && args.length === 0) {
-      message.reply(`*Give me more data* para eu poder trabalhar!\n${this.usage}`);
+      message.reply(`Preciso de mais dados para poder trabalhar!\n${this.usage}`);
 
       return;
     }

--- a/src/services/Acronyms.js
+++ b/src/services/Acronyms.js
@@ -1,0 +1,16 @@
+const { AcronymsApi } = require('../api');
+
+/**
+ *
+ * @param {String} acronym
+ * @returns {Array}
+ */
+const getExactAcronym = async (acronym) => {
+  const { data } = await AcronymsApi.get(acronym);
+
+  return data;
+};
+
+module.exports = {
+  getExactAcronym,
+};

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,3 +1,4 @@
+const Acronyms = require('./Acronyms');
 const Earthquakes = require('./Earthquakes');
 const Warnings = require('./Warnings');
 const Fires = require('./Fires');
@@ -6,6 +7,7 @@ const Winds = require('./Winds');
 const Weather = require('./Weather');
 
 module.exports = {
+  Acronyms,
   Earthquakes,
   Warnings,
   Fires,


### PR DESCRIPTION
## Description
This pull request addresses issue [BOT-58](https://github.com/vostpt/bot/issues/58).
`!acronimo <acronym>` was not working properly due to endpoint not existing anymore.

## Task items:
- [X] Update endpoint to the new API;
- [X] Added service layer to manipulate response and unwrapped data;
- [X] Removed unnecessary `try/catch`