### PR TITLE
[Fix] Execute bot without cooldown env variable

### DIFF
--- a/config/bot.js
+++ b/config/bot.js
@@ -7,9 +7,9 @@ const channels = {
   TRIGGERS_CHANNEL_ID: process.env.TRIGGERS_CHANNEL_ID,
 };
 
-const { COOLDOWN } = process.env;
+const { COOLDOWN = "" } = process.env;
 
-const cooldown = (typeof COOLDOWN === 'undefined' || COOLDOWN.length === 0) ? 10 : COOLDOWN;
+const cooldown = COOLDOWN.length === 0 ? 10 : COOLDOWN;
 
 module.exports = {
   prefix,

--- a/config/bot.js
+++ b/config/bot.js
@@ -9,7 +9,7 @@ const channels = {
 
 const { COOLDOWN } = process.env;
 
-const cooldown = COOLDOWN.length === 0 ? 10 : COOLDOWN;
+const cooldown = (typeof COOLDOWN === 'undefined' || COOLDOWN.length === 0) ? 10 : COOLDOWN;
 
 module.exports = {
   prefix,


### PR DESCRIPTION
## Description
This pull request addresses a bug in PR https://github.com/vostpt/bot/pull/83, about issue [BOT-14](https://github.com/vostpt/bot/issues/14).

## Task items:
- [x] Fixed bug in PR https://github.com/vostpt/bot/pull/83, now bot starts without COOLDOWN .env variable;
