### PR TITLE
[BOT-X] Fix puppeteer sandbox

### DIFF
--- a/src/services/Fuel.js
+++ b/src/services/Fuel.js
@@ -21,7 +21,7 @@ const getFuelStats = async () => {
 * @param {Object} customSettings
 */
 const getFuelScreenshot = async () => {
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox']});
 
   const page = await browser.newPage();
 
@@ -38,6 +38,7 @@ const getFuelScreenshot = async () => {
     },
     encoding: 'base64',
   });
+
   const bufStats2 = await page.screenshot({
     clip: {
       x: 768,

--- a/src/services/Fuel.js
+++ b/src/services/Fuel.js
@@ -21,7 +21,9 @@ const getFuelStats = async () => {
 * @param {Object} customSettings
 */
 const getFuelScreenshot = async () => {
-  const browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox']});
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
 
   const page = await browser.newPage();
 


### PR DESCRIPTION
## Description
This pull request fixes an issue that prevents puppeteer execution without `--no-sandbox` parameter.
This isn't a secure way to execute puppeteer (the best solution would be create a sandbox in which Chromium would run), but since the opened website (in) is owned by VOST, the security threats aren't so high when compared to other websites (non-VOST owned).

Since this is an extremely urgent PR, will merge without the approval of, at least 1 reviewer.

## Task items:
- [x] Fix puppeteer sandbox.
