### PR TITLE
[BOT-X] Disable fuel stats job

### DIFF
--- a/src/jobs/index.js
+++ b/src/jobs/index.js
@@ -51,7 +51,6 @@ class Jobs {
     this.warnings();
     this.fireRisk();
 
-    Jobs.fuelStats();
     Jobs.resetSentNotifications();
   }
 


### PR DESCRIPTION
## Description
Since the fuel-tanker drivers strike ended, sending fuel stats to Twitter doesn't make sense anymore.

## Task items:
- [x] Disable fuel stats tweets;

Since I'll just disable the job, without deleting any code for now, will merge PR without approval.