### PR TITLE
[BOT-X] Change channels in which bot should answer greetings

### DIFF
--- a/config/bot.js
+++ b/config/bot.js
@@ -5,6 +5,7 @@ const channels = {
   FIRES_CHANNEL_ID: process.env.FIRES_CHANNEL_ID,
   WARNINGS_CHANNEL_ID: process.env.WARNINGS_CHANNEL_ID,
   TRIGGERS_CHANNEL_ID: process.env.TRIGGERS_CHANNEL_ID,
+  VOLUNTEERS_CHANNEL_ID: process.env.VOLUNTEERS_CHANNEL_ID,
 };
 
 const { COOLDOWN = '' } = process.env;

--- a/src/events/message.js
+++ b/src/events/message.js
@@ -1,6 +1,6 @@
 const moment = require('moment');
 const { locale } = require('../../config/locale');
-const { prefix, channels } = require('../../config/bot');
+const { prefix } = require('../../config/bot');
 const { react } = require('../helpers');
 
 moment.locale(locale);
@@ -50,9 +50,11 @@ const message = async (client, msg) => {
 
   const { id: channelId } = msg.channel;
 
-  if (channelId === channels.TRIGGERS_CHANNEL_ID) {
-    client.triggers.forEach(({ execute }) => execute(msg, client));
-  }
+  client.triggers.forEach(({ execute, limitToChannels }) => {
+    if (!limitToChannels || limitToChannels.length <= 0 || limitToChannels.includes(channelId)) {
+      execute(msg, client);
+    }
+  });
 
   if (msg.content.startsWith(prefixHelp)) {
     const args = msg.content.slice(prefixHelp.length).split(' ');

--- a/src/triggers/football.js
+++ b/src/triggers/football.js
@@ -1,6 +1,12 @@
+const { channels } = require('../../config/bot');
+
 module.exports = {
   name: 'football',
   description: 'Football related replies',
+  limitToChannels: [
+    channels.TRIGGERS_CHANNEL_ID,
+    channels.VOLUNTEERS_CHANNEL_ID,
+  ],
 
   /**
   * Send to Discord a custom message according to football club

--- a/src/triggers/greetings.js
+++ b/src/triggers/greetings.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const { channels } = require('../../config/bot');
 const { removeAccent } = require('../helpers');
 
 const PERSONAL_MESSAGES = {
@@ -44,6 +45,10 @@ const GREETINGS_BOA_NOITE = [
 module.exports = {
   name: 'greetings',
   description: 'Greeting people',
+  limitToChannels: [
+    channels.TRIGGERS_CHANNEL_ID,
+    channels.VOLUNTEERS_CHANNEL_ID,
+  ],
 
   /**
   * Send to Discord a greeting message according to time and/or user,

--- a/src/triggers/lousyLanguage.js
+++ b/src/triggers/lousyLanguage.js
@@ -1,6 +1,18 @@
+const { removeAccent } = require('../helpers');
+
+const LOUSY_WORDS = [
+  'merda',
+  'caralho',
+  'crl',
+  'puta',
+  'fodase',
+  'foda-se',
+];
+
 module.exports = {
   name: 'lousy language',
   description: 'Avoid lousy language',
+  limitToChannels: [],
 
   /**
   * Send to Discord a message when someone uses lousy language in the server
@@ -9,9 +21,9 @@ module.exports = {
   * @param {Message} message
   */
   async execute(message) {
-    const messageContent = message.content.toLowerCase();
+    const messageContent = removeAccent(message.content.toLowerCase().replace(/\s+/g, ''));
 
-    if (messageContent.includes('merda')) {
+    if (LOUSY_WORDS.some(greeting => messageContent.includes(greeting))) {
       message.reply('Hey https://media1.tenor.com/images/ff97f5136e14b88c76ea8e8488e23855/tenor.gif?itemid=13286953');
     }
   },

--- a/src/triggers/miscellaneous.js
+++ b/src/triggers/miscellaneous.js
@@ -1,6 +1,12 @@
+const { channels } = require('../../config/bot');
+
 module.exports = {
   name: 'Miscellaneous',
   description: 'Miscellaneous things',
+  limitToChannels: [
+    channels.TRIGGERS_CHANNEL_ID,
+    channels.VOLUNTEERS_CHANNEL_ID,
+  ],
 
   /**
   * Send to Discord a custom message according to the trigger or the content of the message


### PR DESCRIPTION
## Description
This pull request changes the channels in which bot sends greetings (lousyLanguage replies in all channels, the other ones only in public and #voluntários channels.

## Task items:
- [x] Change the channels in which bot sends greetings;
- [x] Addition of a new variable `limitToChannels`, with channel ID's where bot should return an answer (if empty, accept all channels).

## Requirements (optional):
- An `ENV` variable needs to be added -> `VOLUNTEERS_CHANNEL_ID`.