### PR TITLE
[BOT-X] Implement notification from another FAQ spreadsheet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,13 @@ FTPPASSWORD=
 CORONAFAQID=
 CORONAFAQGID=
 
+#
+# Government FAQ sheet IDs
+#
+
+GOVFAQID=
+GOVFAQGID=
+
 # Node environment (for Sequelize)
 # test/development/production
 

--- a/config/api.js
+++ b/config/api.js
@@ -5,9 +5,17 @@ const coronaFaqRefs = {
   gid: process.env.CORONAFAQGID,
 };
 
-const faqsURL = `https://docs.google.com/spreadsheets/d/e/${coronaFaqRefs.id}/pub?gid=${coronaFaqRefs.gid}&single=true&output=csv`;
+const coronaFaqsURL = `https://docs.google.com/spreadsheets/d/e/${coronaFaqRefs.id}/pub?gid=${coronaFaqRefs.gid}&single=true&output=csv`;
+
+const govFaqRefs = {
+  id: process.env.GOVFAQID,
+  gid: process.env.GOVFAQGID,
+};
+
+const govFaqsURL = `https://docs.google.com/spreadsheets/d/e/${govFaqRefs.id}/pub?gid=${govFaqRefs.gid}&single=true&output=csv`;
 
 module.exports = {
   baseURL,
-  faqsURL,
+  coronaFaqsURL,
+  govFaqsURL,
 };

--- a/config/api.js
+++ b/config/api.js
@@ -1,18 +1,20 @@
 const baseURL = 'https://bot-api.vost.pt';
 
+const baseFaqsURL = (id, gid) => `https://docs.google.com/spreadsheets/d/e/${id}/pub?gid=${gid}&single=true&output=csv`;
+
 const coronaFaqRefs = {
   id: process.env.CORONAFAQID,
   gid: process.env.CORONAFAQGID,
 };
 
-const coronaFaqsURL = `https://docs.google.com/spreadsheets/d/e/${coronaFaqRefs.id}/pub?gid=${coronaFaqRefs.gid}&single=true&output=csv`;
+const coronaFaqsURL = baseFaqsURL(coronaFaqRefs.id, coronaFaqRefs.gid);
 
 const govFaqRefs = {
   id: process.env.GOVFAQID,
   gid: process.env.GOVFAQGID,
 };
 
-const govFaqsURL = `https://docs.google.com/spreadsheets/d/e/${govFaqRefs.id}/pub?gid=${govFaqRefs.gid}&single=true&output=csv`;
+const govFaqsURL = baseFaqsURL(govFaqRefs.id, govFaqRefs.gid);
 
 module.exports = {
   baseURL,

--- a/src/api/Corona.js
+++ b/src/api/Corona.js
@@ -5,7 +5,7 @@ const neatCsv = require('neat-csv');
 const api = require('./api');
 
 const { ftpCorona } = require('../../config/ftp');
-const { faqsURL } = require('../../config/api');
+const { coronaFaqsURL, govFaqsURL } = require('../../config/api');
 
 const dgsReports = 'https://covid19.min-saude.pt/relatorio-de-situacao/';
 
@@ -44,13 +44,24 @@ const uploadToFtp = async (report) => {
   await client.uploadFrom(fileStream, fileName);
 };
 
-const getFaq = async () => neatCsv(await api.getFileStream(faqsURL), {
-  headers: ['question', 'answer', 'entity', 'hashtag'],
+const getCsv = async (url, headers) => neatCsv(await api.getFileStream(url), {
+  headers,
   skipLines: 1,
 });
+
+const getFaqs = async () => {
+  const coronaResults = await getCsv(coronaFaqsURL, ['question', 'answer', 'entity', 'hashtag']);
+
+  const govResults = await getCsv(govFaqsURL, ['area', 'question', 'answer', 'entity', 'onsite']);
+
+  return {
+    coronaResults,
+    govResults,
+  };
+};
 
 module.exports = {
   getReports,
   uploadToFtp,
-  getFaq,
+  getFaqs,
 };

--- a/src/database/migrations/20200321105621-create-gov-faqs.js
+++ b/src/database/migrations/20200321105621-create-gov-faqs.js
@@ -1,0 +1,33 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('GovFaqs', {
+    id: {
+      allowNull: false,
+      primaryKey: true,
+      type: Sequelize.INTEGER,
+    },
+    area: {
+      type: Sequelize.STRING,
+    },
+    question: {
+      type: Sequelize.STRING,
+    },
+    answer: {
+      type: Sequelize.STRING,
+    },
+    entity: {
+      type: Sequelize.STRING,
+    },
+    onsite: {
+      type: Sequelize.STRING,
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }),
+  down: queryInterface => queryInterface.dropTable('GovFaqs'),
+};

--- a/src/database/models/govfaqs.js
+++ b/src/database/models/govfaqs.js
@@ -1,0 +1,14 @@
+module.exports = (sequelize, DataTypes) => {
+  const GovFaqs = sequelize.define('GovFaqs', {
+    id: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+    },
+    area: DataTypes.STRING,
+    question: DataTypes.STRING,
+    answer: DataTypes.STRING,
+    entity: DataTypes.STRING,
+    onsite: DataTypes.STRING,
+  }, {});
+  return GovFaqs;
+};


### PR DESCRIPTION
## Description
This pull request implements notifications to Discord when a question is answered on Government FAQ spreadsheet.

Since this PR is urgent, will merge without the approval of at least 1 reviewer.

## Task items:
- [x] Implement notifications of new answered questions in Gov FAQ spreadsheet;
- [ ] Jest tests.

## Requirements
Requirements when deploying the current work to an environment (`dev`, `staging` or `production`):

- Add `ENV` variables `GOVFAQID` and `GOVFAQGID`;
- Run Sequelize migrations again (`npx sequelize-cli db:migrate --env [Environment]`).
