### PR TITLE
[BOT-162] Remove infinite loop when splitting long messages

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -140,7 +140,7 @@ const splitMessageString = (msgString, charLimit = 1950, returnFirst = false) =>
 
       messageArray.push(messageToSend);
 
-      lastSentCharacter = lastPos;
+      lastSentCharacter = lastSentCharacter + lastPos;
     } else {
       messageArray.push(msgString.substr(lastSentCharacter, msgStringLength));
       lastSentCharacter = msgStringLength;


### PR DESCRIPTION
<!--
Use the following title format: [BOT-XYZ] <brief description>
-->

## Description
This pull request addresses issue [BOT-162](https://github.com/vostpt/bot/issues/162). There was an infinite loop, which would make the bot crash with OOM when trying to split large messages.

## Task items:
- [x] Fixed issue BOT-162;
