### PR TITLE
[BOT-X] Restore Covid-19 FAQ spreadsheets

### DIFF
--- a/config/api.js
+++ b/config/api.js
@@ -9,7 +9,15 @@ const coronaFaqRefs = {
 
 const coronaFaqsURL = baseFaqsURL(coronaFaqRefs.id, coronaFaqRefs.gid);
 
+const coronaFaqDgsRefs = {
+  id: process.env.CORONAFAQDGSID,
+  gid: process.env.CORONAFAQDGSGID,
+};
+
+const coronaFaqsDgsURL = baseFaqsURL(coronaFaqDgsRefs.id, coronaFaqDgsRefs.gid);
+
 module.exports = {
   baseURL,
   coronaFaqsURL,
+  coronaFaqsDgsURL,
 };

--- a/src/api/Corona.js
+++ b/src/api/Corona.js
@@ -5,7 +5,7 @@ const ftp = require('basic-ftp');
 const api = require('./api');
 
 const { ftpCorona } = require('../../config/ftp');
-const { coronaFaqsURL } = require('../../config/api');
+const { coronaFaqsURL, coronaFaqsDgsURL } = require('../../config/api');
 
 const dgsReports = 'https://covid19.min-saude.pt/relatorio-de-situacao/';
 
@@ -67,7 +67,10 @@ const uploadToFtp = async (report) => {
   await client.uploadFrom(fileStream, fileName);
 };
 
-const getFaqs = async () => api.get(coronaFaqsURL);
+const getFaqs = async () => ({
+  coronaFaqs: await api.get(coronaFaqsURL),
+  coronaDgsFaqs: await api.get(coronaFaqsDgsURL),
+});
 
 module.exports = {
   md5FromUrl,

--- a/src/database/migrations/20200410214421-create-corona-dgs-faqs.js
+++ b/src/database/migrations/20200410214421-create-corona-dgs-faqs.js
@@ -1,0 +1,36 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('CoronaDgsFaqs', {
+    id: {
+      allowNull: false,
+      primaryKey: true,
+      type: Sequelize.INTEGER,
+    },
+    question: {
+      type: Sequelize.STRING,
+    },
+    answer: {
+      type: Sequelize.STRING,
+    },
+    entity: {
+      type: Sequelize.STRING,
+    },
+    onsite: {
+      type: Sequelize.STRING,
+    },
+    awaiting: {
+      type: Sequelize.BOOLEAN,
+    },
+    newAnswer: {
+      type: Sequelize.BOOLEAN,
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+  }),
+  down: queryInterface => queryInterface.dropTable('CoronaDgsFaqs'),
+};

--- a/src/database/models/coronadgsfaqs.js
+++ b/src/database/models/coronadgsfaqs.js
@@ -1,0 +1,15 @@
+module.exports = (sequelize, DataTypes) => {
+  const CoronaDgsFaqs = sequelize.define('CoronaDgsFaqs', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+    },
+    question: DataTypes.STRING,
+    answer: DataTypes.STRING,
+    entity: DataTypes.STRING,
+    onsite: DataTypes.STRING,
+    awaiting: DataTypes.BOOLEAN,
+    newAnswer: DataTypes.BOOLEAN,
+  }, {});
+  return CoronaDgsFaqs;
+};

--- a/src/jobs/index.js
+++ b/src/jobs/index.js
@@ -193,12 +193,12 @@ class Jobs {
   }
 
   /**
-   * Update new answered FAQS in Covid-19 spreadsheet
+   * Update new answered FAQS in Covid-19 spreadsheets
    */
   getCoronaFaqs() {
     const rule = new schedule.RecurrenceRule();
 
-    rule.minute = new schedule.Range(1, 57, 3);
+    rule.minute = new schedule.Range(1, 55, 5);
     rule.second = 15;
 
     schedule.scheduleJob(rule, () => {


### PR DESCRIPTION
## Description
This pull request restores monitoring of the two spreadsheets where DGS and the government inserts the answers about Covid-19.

I made a PR that removed the monitoring of one spreadsheet (of the two) without being sure that the spreadsheet wasn't needed. For that reason, I will have to approve PR without the approval of at least 1 reviewer.

## Task items:
- [x] Fixed spreadsheet issue;
- [ ] Tests;

## Requirements
Requirements when deploying the current work to an environment (`dev`, `staging` or `production`):

- Add `ENV` variables `CORONAFAQDGSID` and `CORONAFAQDGSGID` ;
- Migrate Sequelize DB.
