### PR TITLE
[BOT-X] Refactor Discord command authorizations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,15 +26,10 @@ DGSCORONA_CHANNEL_ID=
 JOURNAL_CHANNEL_ID=
 
 #
-# Discord roles
+# Discord commands user permission list
 #
 
-COREROLE=
-
-#
-# Discord user permission list
-#
-
+CORONAUPDATEROLES=
 CORONAUPDATEUSERS=
 
 #

--- a/README.md
+++ b/README.md
@@ -72,15 +72,10 @@ DGSCORONA_CHANNEL_ID=
 JOURNAL_CHANNEL_ID=
 
 #
-# Discord roles
+# Discord commands user permission list
 #
 
-COREROLE=
-
-#
-# Discord user permission list
-#
-
+CORONAUPDATEROLES=
 CORONAUPDATEUSERS=
 
 #

--- a/config/bot.js
+++ b/config/bot.js
@@ -15,15 +15,19 @@ const channels = {
   JOURNAL_CHANNEL_ID: process.env.JOURNAL_CHANNEL_ID,
 };
 
-const roles = {
-  core: process.env.COREROLE,
-};
-
 const coronaUpdateUsers = process.env.CORONAUPDATEUSERS;
 
 const userLists = {
   coronaUpdate: typeof coronaUpdateUsers !== 'undefined'
     ? coronaUpdateUsers.split(',')
+    : [],
+};
+
+const coronaUpdateRoles = process.env.CORONAUPDATEROLES;
+
+const roleLists = {
+  coronaUpdate: typeof coronaUpdateRoles !== 'undefined'
+    ? coronaUpdateRoles.split(',')
     : [],
 };
 
@@ -36,8 +40,8 @@ const betaMode = (/true/i).test(process.env.BETA_MODE);
 module.exports = {
   prefix,
   channels,
-  roles,
   userLists,
+  roleLists,
   cooldown,
   betaMode,
 };


### PR DESCRIPTION
## Description
This pull request refactors authorizations to use Discord commands.

## Task items:
- [x] Refactor Discord command authorizations - Now both role and user ID's can be defined in `.env` file, without changing source code.

## Requirements
Requirements when deploying the current work to an environment (`dev`, `staging` or `production`):

- Add `ENV` variable `CORONAUPDATEROLES`;
- `ENV` variable `COREROLE` can be removed.
