### PR TITLE
[BOT-X] Add PT Presidency handle to DRE decrees

### DIFF
--- a/src/services/Journal.js
+++ b/src/services/Journal.js
@@ -30,6 +30,7 @@ const twitterAccounts = {
   PLANEAMENTO: '@planeamento_pt',
   'MODERNIZAÇÃO DO ESTADO E DA ADMINISTRAÇÃO PÚBLICA': '@modernizacao_pt',
   'COESÃO TERRITORIAL': '@coesao_pt',
+  'PRESIDÊNCIA DA REPÚBLICA': '@presidencia',
 };
 
 const serieNo = {


### PR DESCRIPTION
## Description
This pull request adds Portuguese Presidency Twitter account to DRE decrees.

## Task items:
- [x] Add Portuguese Presidency Twitter account ([@presidencia](https://twitter.com/presidencia)) to DRE decrees.
